### PR TITLE
Add scroll strategy config option for scroll behaviour customization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ng2-date-picker-demo",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ng2-date-picker-demo",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "license": "MIT",
       "dependencies": {
         "@angular/cdk": "^16.1.7",

--- a/projects/ng2-date-picker/src/lib/date-picker/date-picker-config.model.ts
+++ b/projects/ng2-date-picker/src/lib/date-picker/date-picker-config.model.ts
@@ -3,6 +3,7 @@ import {IDayCalendarConfig, IDayCalendarConfigInternal} from '../day-calendar/da
 import {IMonthCalendarConfig, IMonthCalendarConfigInternal} from '../month-calendar/month-calendar-config';
 import {ITimeSelectConfig, ITimeSelectConfigInternal} from '../time-select/time-select-config.model';
 import {ElementRef} from '@angular/core';
+import {ScrollStrategyOptions} from '@angular/cdk/overlay';
 
 export interface IConfig {
   closeOnSelect?: boolean;
@@ -17,6 +18,7 @@ export interface IConfig {
   opens?: TOpens;
   hideInputContainer?: boolean;
   hideOnOutsideClick?: boolean;
+  scrollStrategy?: ScrollStrategyOptions;
 }
 
 export interface IDatePickerConfig extends IConfig,

--- a/projects/ng2-date-picker/src/lib/date-picker/date-picker-config.model.ts
+++ b/projects/ng2-date-picker/src/lib/date-picker/date-picker-config.model.ts
@@ -3,7 +3,6 @@ import {IDayCalendarConfig, IDayCalendarConfigInternal} from '../day-calendar/da
 import {IMonthCalendarConfig, IMonthCalendarConfigInternal} from '../month-calendar/month-calendar-config';
 import {ITimeSelectConfig, ITimeSelectConfigInternal} from '../time-select/time-select-config.model';
 import {ElementRef} from '@angular/core';
-import {ScrollStrategy} from '@angular/cdk/overlay';
 
 export interface IConfig {
   closeOnSelect?: boolean;
@@ -18,8 +17,9 @@ export interface IConfig {
   opens?: TOpens;
   hideInputContainer?: boolean;
   hideOnOutsideClick?: boolean;
-  scrollStrategy?: ScrollStrategy;
+  scrollStrategy?: any;
 }
+
 
 export interface IDatePickerConfig extends IConfig,
                                            IDayCalendarConfig,

--- a/projects/ng2-date-picker/src/lib/date-picker/date-picker-config.model.ts
+++ b/projects/ng2-date-picker/src/lib/date-picker/date-picker-config.model.ts
@@ -3,7 +3,7 @@ import {IDayCalendarConfig, IDayCalendarConfigInternal} from '../day-calendar/da
 import {IMonthCalendarConfig, IMonthCalendarConfigInternal} from '../month-calendar/month-calendar-config';
 import {ITimeSelectConfig, ITimeSelectConfigInternal} from '../time-select/time-select-config.model';
 import {ElementRef} from '@angular/core';
-import {ScrollStrategyOptions} from '@angular/cdk/overlay';
+import {ScrollStrategy} from '@angular/cdk/overlay';
 
 export interface IConfig {
   closeOnSelect?: boolean;
@@ -18,7 +18,7 @@ export interface IConfig {
   opens?: TOpens;
   hideInputContainer?: boolean;
   hideOnOutsideClick?: boolean;
-  scrollStrategy?: ScrollStrategyOptions;
+  scrollStrategy?: ScrollStrategy;
 }
 
 export interface IDatePickerConfig extends IConfig,

--- a/projects/ng2-date-picker/src/lib/date-picker/date-picker.component.html
+++ b/projects/ng2-date-picker/src/lib/date-picker/date-picker.component.html
@@ -19,6 +19,7 @@
                [cdkConnectedOverlayOrigin]="origin || trigger"
                [cdkConnectedOverlayOpen]="areCalendarsShown"
                [cdkConnectedOverlayHasBackdrop]="false"
+               [cdkConnectedOverlayScrollStrategy]="scrollStrategy"
                (overlayOutsideClick)="onBodyClick($event)">
     <div #container>
       <div [attr.data-hidden]="!areCalendarsShown"

--- a/projects/ng2-date-picker/src/lib/date-picker/date-picker.component.ts
+++ b/projects/ng2-date-picker/src/lib/date-picker/date-picker.component.ts
@@ -52,7 +52,7 @@ import {SelectEvent} from '../common/types/selection-event.enum';
 import {ISelectionEvent} from '../common/types/selection-event.model';
 import {Dayjs, UnitType} from 'dayjs';
 import {dayjsRef} from '../common/dayjs/dayjs.ref';
-import {ConnectionPositionPair} from '@angular/cdk/overlay';
+import {ConnectionPositionPair, ScrollStrategyOptions} from '@angular/cdk/overlay';
 
 @Component({
   selector: 'dp-date-picker',
@@ -125,6 +125,7 @@ export class DatePickerComponent implements OnChanges,
   };
   selectEvent = SelectEvent;
   origin: ElementRef | HTMLElement;
+  scrollStrategy: ScrollStrategyOptions;
   private onOpenDelayTimeoutHandler;
 
   constructor(private readonly dayPickerService: DatePickerService,
@@ -297,6 +298,7 @@ export class DatePickerComponent implements OnChanges,
     this.initValidators();
     this.overlayPosition = this.dayPickerService.getOverlayPosition(this.componentConfig);
     this.origin = this.utilsService.getNativeElement(this.componentConfig.inputElementContainer);
+    this.scrollStrategy = this.dayPickerService.getScrollStrategy(this.componentConfig.scrollStrategy);
   }
 
   inputFocused(): void {

--- a/projects/ng2-date-picker/src/lib/date-picker/date-picker.component.ts
+++ b/projects/ng2-date-picker/src/lib/date-picker/date-picker.component.ts
@@ -52,7 +52,7 @@ import {SelectEvent} from '../common/types/selection-event.enum';
 import {ISelectionEvent} from '../common/types/selection-event.model';
 import {Dayjs, UnitType} from 'dayjs';
 import {dayjsRef} from '../common/dayjs/dayjs.ref';
-import {ConnectionPositionPair, ScrollStrategyOptions} from '@angular/cdk/overlay';
+import {ConnectionPositionPair, ScrollStrategy} from '@angular/cdk/overlay';
 
 @Component({
   selector: 'dp-date-picker',
@@ -125,7 +125,7 @@ export class DatePickerComponent implements OnChanges,
   };
   selectEvent = SelectEvent;
   origin: ElementRef | HTMLElement;
-  scrollStrategy: ScrollStrategyOptions;
+  scrollStrategy: ScrollStrategy;
   private onOpenDelayTimeoutHandler;
 
   constructor(private readonly dayPickerService: DatePickerService,

--- a/projects/ng2-date-picker/src/lib/date-picker/date-picker.service.ts
+++ b/projects/ng2-date-picker/src/lib/date-picker/date-picker.service.ts
@@ -9,7 +9,7 @@ import {ITimeSelectConfig} from '../time-select/time-select-config.model';
 import {CalendarMode} from '../common/types/calendar-mode';
 import {Dayjs} from 'dayjs';
 import {IDayTimeCalendarConfig} from '../day-time-calendar/day-time-calendar-config.model';
-import {ConnectionPositionPair} from '@angular/cdk/overlay';
+import {ConnectionPositionPair, ScrollStrategyOptions} from '@angular/cdk/overlay';
 
 @Injectable({
   providedIn: 'root'
@@ -33,6 +33,7 @@ export class DatePickerService {
   };
 
   constructor(private readonly utilsService: UtilsService,
+              private readonly scrollOptions: ScrollStrategyOptions,
               private readonly timeSelectService: TimeSelectService,
               private readonly daytimeCalendarService: DayTimeCalendarService) {
   }
@@ -126,6 +127,14 @@ export class DatePickerService {
       overlayX: opens ? opens === 'left' ? 'start' : 'end' : 'start',
       overlayY: drops ? drops === 'up' ? 'bottom' : 'top' : 'top',
     }];
+  }
+
+  getScrollStrategy(scrollStrategyOption: ScrollStrategyOptions): ScrollStrategyOptions {
+    if (scrollStrategyOption && scrollStrategyOption instanceof ScrollStrategyOptions) {
+      return scrollStrategyOption;
+    }
+
+    return this.scrollOptions.noop(); // close, blocking, reposition
   }
 
   private static getDefaultFormatByMode(mode: CalendarMode): string {

--- a/projects/ng2-date-picker/src/lib/date-picker/date-picker.service.ts
+++ b/projects/ng2-date-picker/src/lib/date-picker/date-picker.service.ts
@@ -129,9 +129,9 @@ export class DatePickerService {
     }];
   }
 
-  getScrollStrategy(scrollStrategyOption: ScrollStrategyOptions): ScrollStrategyOptions {
-    if (scrollStrategyOption && scrollStrategyOption instanceof ScrollStrategyOptions) {
-      return scrollStrategyOption;
+  getScrollStrategy(scrollStrategy: ScrollStrategy): ScrollStrategy {
+    if (scrollStrategy) {
+      return scrollStrategy;
     }
 
     return this.scrollOptions.noop(); // close, blocking, reposition

--- a/projects/ng2-date-picker/src/lib/date-picker/date-picker.service.ts
+++ b/projects/ng2-date-picker/src/lib/date-picker/date-picker.service.ts
@@ -9,7 +9,7 @@ import {ITimeSelectConfig} from '../time-select/time-select-config.model';
 import {CalendarMode} from '../common/types/calendar-mode';
 import {Dayjs} from 'dayjs';
 import {IDayTimeCalendarConfig} from '../day-time-calendar/day-time-calendar-config.model';
-import {ConnectionPositionPair, ScrollStrategyOptions} from '@angular/cdk/overlay';
+import {ConnectionPositionPair, ScrollStrategyOptions, ScrollStrategy} from '@angular/cdk/overlay';
 
 @Injectable({
   providedIn: 'root'


### PR DESCRIPTION
### PR Summary

This PR introduces configurable scrolling options for the calendar component, allowing for customized behavior when scrolling the page while the calendar is open.

**Default Behavior (`noop`):**
- The default option, `noop`, maintains the current behavior where the calendar remains open and the page is scrollable.

**New Options:**
1. **`close`**: Closes the calendar when the user scrolls. Set via the `scrollStrategy` property.
    ```javascript
    const config = {
      ...,
      scrollStrategy: this.scrollOptions.close(),
    };
    ```

2. **`block`**: Prevents the entire page from scrolling when the calendar is open.
    ```javascript
    const config = {
      ...,
      scrollStrategy: this.scrollOptions.block(),
    };
    ```

3. **`reposition`**: Repositions the calendar to stay attached to the origin element when the page is scrolled.
    ```javascript
    const config = {
      ...,
      scrollStrategy: this.scrollOptions.reposition(),
    };
    ```

These new options provide greater flexibility in how the calendar interacts with page scrolling, enhancing user experience based on different use cases.
